### PR TITLE
Fix improper version string in `engines` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "=>14.16"
+		"node": ">=14.16"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
https://github.com/sindresorhus/is-executable/blob/89d1cb609c2d75bcbdb5744b35c06452cb21c0b8/package.json#L10-L12

Should be `>=`, not `=>`. The package cannot be installed as-is.